### PR TITLE
공인중개사 리뷰 관리 페이지 버그 수정 / 매물 정보 가져올 떄의 객체 수정

### DIFF
--- a/src/main/java/com/kdt/repositories/UploadReviewApprovalRepository.java
+++ b/src/main/java/com/kdt/repositories/UploadReviewApprovalRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.kdt.domain.entities.UploadReviewApproval;
 
 public interface UploadReviewApprovalRepository extends JpaRepository<UploadReviewApproval, Long>{
-	UploadReviewApproval findByEstateCodeAndApprovalCodeIn(Long estateCode, List<String> approvalCodes);
+	List<UploadReviewApproval> findAllByEstateCodeAndApprovalCodeIn(Long estateCode, List<String> approvalCodes);
 	
 	Long countByEstateCodeAndApprovalCodeIn(Long estateCode, List<String> approvalCodes);
 }

--- a/src/main/java/com/kdt/services/EstateService.java
+++ b/src/main/java/com/kdt/services/EstateService.java
@@ -109,6 +109,10 @@ public class EstateService {
 		List<Estate> eList = eRepo.findAllByRealEstateAgentEmail(loginId);
 		
 		List<EstateDTO> list = eMapper.toDtoList(eList);
+		
+		for(EstateDTO dto : list) {
+			dto.getRealEstateAgent().setPw(null);
+		}
 
 		return list;
 	}
@@ -117,12 +121,21 @@ public class EstateService {
 		List<Estate> eList = eRepo.findAll();
 		List<EstateDTO> list = eMapper.toDtoList(eList);
 
+		for(EstateDTO dto : list) {
+			dto.getRealEstateAgent().setPw(null);
+		}
+		
 		return list;
 	}
 	public List<EstateDTO> selectLimitAll() {
 		List<Estate> eList = eRepo.findTop6ByOrderByEstateIdDesc();
 		System.out.println(eList.get(3).getAddress1());
 		List<EstateDTO> list = eMapper.toDtoList(eList);
+		
+		for(EstateDTO dto : list) {
+			dto.getRealEstateAgent().setPw(null);
+		}
+		
 		return list;
 	}
 	public List<EstateDTO> selectWatchAll(List<Long> recent) {
@@ -135,6 +148,11 @@ public class EstateService {
 	        }
 	    }
 	    List<EstateDTO> list = eMapper.toDtoList(new ArrayList<>(estateMap.values()));
+	    
+	    for(EstateDTO dto : list) {
+			dto.getRealEstateAgent().setPw(null);
+		}
+	    
 	    return list;
 	}
 
@@ -148,6 +166,8 @@ public class EstateService {
 	public EstateDTO getById(Long estateId) {
 		Estate estate = eRepo.findById(estateId).get();
 		EstateDTO dto = eMapper.toDto(estate);
+		
+		dto.getRealEstateAgent().setPw(null);
 
 		return dto;
 	}
@@ -300,6 +320,9 @@ public class EstateService {
 	public EstateDTO selectEstate(Long id) {
 		Estate e = eRepo.findById(id).get();
 		EstateDTO edto = eMapper.toDto(e);
+		
+		edto.getRealEstateAgent().setPw(null);
+		
 		return edto;
 	}
 }

--- a/src/main/java/com/kdt/services/ReviewApprovalService.java
+++ b/src/main/java/com/kdt/services/ReviewApprovalService.java
@@ -59,9 +59,9 @@ public class ReviewApprovalService {
 		List<UploadReviewApproval> rList = new ArrayList<>();
 
 		for (UploadEstate estate : estateList) {
-			UploadReviewApproval result = uraRepo.findByEstateCodeAndApprovalCodeIn(estate.getEstateId(), approvalCodes);
-			if (result != null) {
-				rList.add(result);
+			List<UploadReviewApproval> results = uraRepo.findAllByEstateCodeAndApprovalCodeIn(estate.getEstateId(), approvalCodes);
+			if (results != null) {
+				rList.addAll(results);
 			} 
 		}
 


### PR DESCRIPTION
공인중개사 리뷰 관리 페이지 버그 수정

매물 정보 가져올 떄 객채에 공인중개사 비밀번호도 함께 가져오는 경우에 대한 수정 사항