### PR TITLE
매물 판매 상황 추가

### DIFF
--- a/src/main/java/com/kdt/controllers/EstateController.java
+++ b/src/main/java/com/kdt/controllers/EstateController.java
@@ -71,13 +71,6 @@ public class EstateController {
 		return ResponseEntity.ok(list);
 	}
 
-//	@GetMapping("estateUpdate/{estateId}")
-//	public ResponseEntity<UploadEstateDTO> selectById(@PathVariable String estateId) {
-//		UploadEstateDTO dto = eServ.selectById(Long.parseLong(estateId));
-//
-//		return ResponseEntity.ok(dto);
-//	}
-
 	@GetMapping("estateInfo/{estateId}")
 	public ResponseEntity<EstateDTO> getById(@PathVariable String estateId) {
 		EstateDTO dto = eServ.getById(Long.parseLong(estateId));
@@ -116,6 +109,14 @@ public class EstateController {
 		} catch (Exception e) {
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
 		}
+	}
+	
+	@PutMapping("/updateStatus/{estateId}")
+	public ResponseEntity<Void> updateStatus(@PathVariable String estateId) {
+		
+		eServ.updateStatus(Long.parseLong(estateId));
+		
+		return ResponseEntity.ok().build();
 	}
 
 	@DeleteMapping("/{estateId}")

--- a/src/main/java/com/kdt/domain/entities/Estate.java
+++ b/src/main/java/com/kdt/domain/entities/Estate.java
@@ -23,9 +23,6 @@ public class Estate {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long estateId;
 
-//	@Column(name = "writer")
-//	private String writer;
-
 	@Column(name = "deposit")
 	private Long deposit;
 
@@ -70,6 +67,9 @@ public class Estate {
 
 	@Column(name = "write_date")
 	private Timestamp writeDate;
+	
+	@Column(name = "sold_status")
+	private boolean soldStatus;
 	
 	@OneToOne
 	@JoinColumn(name = "room_code", referencedColumnName = "room_id")
@@ -231,6 +231,14 @@ public class Estate {
 		this.writeDate = writeDate;
 	}
 
+	public boolean isSoldStatus() {
+		return soldStatus;
+	}
+
+	public void setSoldStatus(boolean soldStatus) {
+		this.soldStatus = soldStatus;
+	}
+
 	public Room getRoom() {
 		return room;
 	}
@@ -297,9 +305,9 @@ public class Estate {
 
 	public Estate(Long estateId, Long deposit, Long price, double area, Long zipcode, String address1, String address2,
 			double latitude, double longitude, Long roomFloors, Long buildingFloors, Long maintenanceCost, String title,
-			String contents, String memo, Timestamp writeDate, Room room, Structure structure, Building building,
-			Transaction transaction, HeatingSystem heatingSystem, Set<EstateOption> optionList, Set<EstateImage> images,
-			RealEstateAgent realEstateAgent) {
+			String contents, String memo, Timestamp writeDate, boolean soldStatus, Room room, Structure structure,
+			Building building, Transaction transaction, HeatingSystem heatingSystem, Set<EstateOption> optionList,
+			Set<EstateImage> images, RealEstateAgent realEstateAgent) {
 		super();
 		this.estateId = estateId;
 		this.deposit = deposit;
@@ -317,6 +325,7 @@ public class Estate {
 		this.contents = contents;
 		this.memo = memo;
 		this.writeDate = writeDate;
+		this.soldStatus = soldStatus;
 		this.room = room;
 		this.structure = structure;
 		this.building = building;

--- a/src/main/java/com/kdt/dto/EstateDTO.java
+++ b/src/main/java/com/kdt/dto/EstateDTO.java
@@ -23,6 +23,7 @@ public class EstateDTO {
     private String contents;
     private String memo;
     private Timestamp writeDate;
+    private boolean soldStatus;
     private RoomDTO room;
     private StructureDTO structure;
     private BuildingDTO building;
@@ -127,6 +128,12 @@ public class EstateDTO {
 	public void setWriteDate(Timestamp writeDate) {
 		this.writeDate = writeDate;
 	}
+	public boolean isSoldStatus() {
+		return soldStatus;
+	}
+	public void setSoldStatus(boolean soldStatus) {
+		this.soldStatus = soldStatus;
+	}
 	public RoomDTO getRoom() {
 		return room;
 	}
@@ -175,6 +182,41 @@ public class EstateDTO {
 	public void setRealEstateAgent(RealEstateAgent realEstateAgent) {
 		this.realEstateAgent = realEstateAgent;
 	}
-	
-    
+	public EstateDTO(Long estateId, Long deposit, Long price, double area, Long zipcode, String address1,
+			String address2, double latitude, double longitude, Long roomFloors, Long buildingFloors,
+			Long maintenanceCost, String title, String contents, String memo, Timestamp writeDate, boolean soldStatus,
+			RoomDTO room, StructureDTO structure, BuildingDTO building, TransactionDTO transaction,
+			HeatingSystemDTO heatingSystem, Set<EstateOptionDTO> optionList, Set<EstateImageDTO> images,
+			RealEstateAgent realEstateAgent) {
+		super();
+		this.estateId = estateId;
+		this.deposit = deposit;
+		this.price = price;
+		this.area = area;
+		this.zipcode = zipcode;
+		this.address1 = address1;
+		this.address2 = address2;
+		this.latitude = latitude;
+		this.longitude = longitude;
+		this.roomFloors = roomFloors;
+		this.buildingFloors = buildingFloors;
+		this.maintenanceCost = maintenanceCost;
+		this.title = title;
+		this.contents = contents;
+		this.memo = memo;
+		this.writeDate = writeDate;
+		this.soldStatus = soldStatus;
+		this.room = room;
+		this.structure = structure;
+		this.building = building;
+		this.transaction = transaction;
+		this.heatingSystem = heatingSystem;
+		this.optionList = optionList;
+		this.images = images;
+		this.realEstateAgent = realEstateAgent;
+	}
+	public EstateDTO() {
+		super();
+	}
+
 }

--- a/src/main/java/com/kdt/repositories/EstateRepository.java
+++ b/src/main/java/com/kdt/repositories/EstateRepository.java
@@ -16,4 +16,7 @@ public interface EstateRepository extends JpaRepository<Estate, Long> {
 	
 	@Query("select m from Estate m order by estateId desc limit 6")
 	 List<Estate> findTop6ByOrderByEstateIdDesc();
+	
+	@Query("SELECT e FROM Estate e WHERE e.soldStatus = false")
+    List<Estate> findAllBySoldStatusFalse();
 }

--- a/src/main/java/com/kdt/services/EstateService.java
+++ b/src/main/java/com/kdt/services/EstateService.java
@@ -118,7 +118,7 @@ public class EstateService {
 	}
 
 	public List<EstateDTO> selectAll() {
-		List<Estate> eList = eRepo.findAll();
+		List<Estate> eList = eRepo.findAllBySoldStatusFalse();
 		List<EstateDTO> list = eMapper.toDtoList(eList);
 
 		for(EstateDTO dto : list) {
@@ -324,5 +324,14 @@ public class EstateService {
 		edto.getRealEstateAgent().setPw(null);
 		
 		return edto;
+	}
+	
+	public void updateStatus(Long estateId) {
+		Estate estate = eRepo.findById(estateId).get();
+		estate.setSoldStatus(!estate.isSoldStatus());
+		
+		System.out.println(estate);
+		
+		eRepo.save(estate);
 	}
 }


### PR DESCRIPTION
매물 DB에 판매중인 상황을 나타내는 sold_status 칼럼 추가
false면 판매중 true면 판매완료
엔티티, DTO 연동하여 변경

지도에 나오는 매물 정보를 판매중인 매물 정보로만 한정되게 변경

매물 판매 상황을 변경하는 서비스 코드 추가